### PR TITLE
documentation: clarify/correct temp descriptions used in mortality impact functions

### DIFF
--- a/doc/science.md
+++ b/doc/science.md
@@ -1063,7 +1063,7 @@ morbidity.
 The number of additional deaths from vector-borne diseases,
 $D_{t,r}^{v}$ is given by:
 
-$$D_{t,r}^{v} = D_{1990,r}^{v}\alpha_{r}^{v}\left( T_{t} - T_{1990} \right)^{\beta}\left( \frac{y_{t,r}}{y_{1990,r}} \right)^{\gamma}$$ {#eq:HV tag="HV"}
+$$D_{t,r}^{v} = D_{1990,r}^{v}\alpha_{r}^{v}T_{t}^{\beta}\left( \frac{y_{t,r}}{y_{1990,r}} \right)^{\gamma}$$ {#eq:HV tag="HV"}
 
 where
 
@@ -1155,8 +1155,8 @@ where
 
 -   $t$ indexes time;
 
--   $T$ denotes the change in regional mean temperature (in degree
-    Celsius);
+-   $T_{t}$ denotes the mean temperature in year $t$, in degrees Celcius
+    (C);
 
 -   $\alpha$ and $\beta$ are parameters, specified in Tables HC.2-4 (in
     probabilistic mode all probablitiy distributions are constrained so


### PR DESCRIPTION
# Documentation Bug Fixes
## Vector Mortality Equation

The vector mortality impact functions are defined in terms of `ImpactVectorBorneDiseasesComponent.temp[t,r]`, which is equal in all regions to `climatedynamics.temp[t]`. See, for example, line 39 of ImpactVectorBorneDiseases.jl:

```
        v.dengue[t, r] = p.dfbs[r] * p.population[t, r] * p.dfch[r] * p.temp[t, r]^p.dfnl * (ypc / ypc90)^p.vbel
```

The documentation previously indicated that the temperature term is (t[t]-t[1990]), but this is inaccurate and has been updated
## CardioRespiratory Mortality Variable Definitions

The definition for $T_t$ given in the variable definitions below equation `HC.2` describes the variable as regional temperature. This is untrue - the variable is global temperature change since pre-industrial. This has been updated with the definition for $T_t$ used int the CardioRespiratory section.
