### PR TITLE
Clarified error message in ClimateCH4CycleComponent.jl

### DIFF
--- a/src/ClimateCH4CycleComponent.jl
+++ b/src/ClimateCH4CycleComponent.jl
@@ -30,7 +30,7 @@ function run_timestep(s::climatech4cycle, t::Int)
         v.acch4[t] = v.acch4[t - 1] + 0.3597 * p.globch4[t] - v.ch4decay * (v.acch4[t - 1] - p.ch4pre)
 
         if v.acch4[t] < 0
-            error("ch4 atmospheric concentration out of range in $t")
+            error("ch4 atmospheric concentration, '$(v.acch4[t])', unexpectedly less than zero at timestep $t")
         end
     end
 end


### PR DESCRIPTION
I clarified in the error message that the atmospheric concentration was erroneously negative, and added the out-of-bounds data to error message.

In [this commit](https://github.com/NHDaly/fund.jl/blob/9bb97fea096b941a5626dcc2ddeb4dfea89f8261/examples/fund_demo.ipynb) I ran the example .ipynb, which was generating this error, and it shows the updated error message. It shows that for some reason the atmospheric concentration was `-Inf`, which might be more useful in diagnosing the problem. :)